### PR TITLE
Update sampler.cpp

### DIFF
--- a/src/sampler.cpp
+++ b/src/sampler.cpp
@@ -876,17 +876,19 @@ RcppExport SEXP sampler(const SEXP y_in, const SEXP draws_in,
         
         for (int ii = 0; ii<m; ii++) {
           for (int jj = 0; jj<r; jj++) {
-            if(armafacload(ii,jj) == 0) {
-              if(R::rbinom( 1, 0.5 )==0){
+            if(armarestr(ii,jj) != 0){
+              if(armafacload(ii,jj) == 0) {
+                if(R::rbinom( 1, 0.5 )==0){
+                  armafacload(ii,jj) = facloadtol;
+                }else{
+                  armafacload(ii,jj) = -facloadtol;
+                }
+              }else if(armafacload(ii,jj) < facloadtol && armafacload(ii,jj) > 0){
                 armafacload(ii,jj) = facloadtol;
-              }else{
+              }else if (armafacload(ii,jj) > -facloadtol && armafacload(ii,jj) < 0){
                 armafacload(ii,jj) = -facloadtol;
               }
-            }else if(armafacload(ii,jj) < facloadtol && armafacload(ii,jj) > 0){
-              armafacload(ii,jj) = facloadtol;
-            }else if (armafacload(ii,jj) > -facloadtol && armafacload(ii,jj) < 0){
-              armafacload(ii,jj) = -facloadtol;
-            } 
+            }
           }
         }
         


### PR DESCRIPTION
bugfix: facloadtol used to overwrite zero restrictions on loading matrix.