### PR TITLE
Use DBL_EPSILON instead of DOUBLE_EPS to allow STRICT_R_HEADERS

### DIFF
--- a/src/sampler.cpp
+++ b/src/sampler.cpp
@@ -50,7 +50,7 @@ double do_rgig1(double lambda, double chi, double psi) {
 
   double res;
   // circumvent GIGrvg in these cases
-  if (chi < 10 * DOUBLE_EPS) {
+  if (chi < 10 * DBL_EPSILON) {
     /* special cases which are basically Gamma and Inverse Gamma distribution */
     if (lambda > 0.0) {
       res = R::rgamma(lambda, 2.0/psi);
@@ -60,7 +60,7 @@ double do_rgig1(double lambda, double chi, double psi) {
     }
   }
 
-  else if (psi < 10 * DOUBLE_EPS) {
+  else if (psi < 10 * DBL_EPSILON) {
     /* special cases which are basically Gamma and Inverse Gamma distribution */
     if (lambda > 0.0) {
       res = R::rgamma(lambda, 2.0/psi);  // fixed


### PR DESCRIPTION
Dear Gregor, dear `factorstochvol` team,

`Rcpp` has been preparing a new release in which `STRICT_R_HEADERS` will be on by default -- see [issue #1158 for all details](https://github.com/RcppCore/Rcpp/issues/1158).  We have been at since April (!!).   The change requires prefixing a number of (potentially clashing) functions with `Rf_` and it affects a number of (old) `#define statements and uses of _e.g._ `PI` (which must besome `M_PI`).

Your package has a similar issue (that had not come up in prior roughlt monthly runs): in `src/sampler.cpp` you twice use `DOUBLE_EPS` but the overlords now want us all to use `DBP_EPSILON` (from `float.h` or equivalently `cfloat`).  

The PR makes the change, and allows `factorstochvol` to build and test under the change that upcoming `Rcpp` version.  It would be great if you could fold the change in and get it to CRAN before January.

Let me know if you have any questions.  

Best,  Dirk